### PR TITLE
Fix some issues flagged by Symfony container linter.

### DIFF
--- a/src/Factory/MollieGatewayConfigFactory.php
+++ b/src/Factory/MollieGatewayConfigFactory.php
@@ -61,4 +61,9 @@ final class MollieGatewayConfigFactory implements MollieGatewayConfigFactoryInte
 
         return $mollieGatewayConfig;
     }
+
+    public function createNew(): MollieGatewayConfigInterface
+    {
+        return $this->mollieGatewayConfigFactory->createNew();
+    }
 }

--- a/src/Factory/MollieGatewayConfigFactoryInterface.php
+++ b/src/Factory/MollieGatewayConfigFactoryInterface.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 
 namespace SyliusMolliePlugin\Factory;
 
+use Sylius\Component\Resource\Factory\FactoryInterface;
 use SyliusMolliePlugin\Entity\GatewayConfigInterface;
 use SyliusMolliePlugin\Entity\MollieGatewayConfigInterface;
 use SyliusMolliePlugin\Payments\Methods\MethodInterface;
 
-interface MollieGatewayConfigFactoryInterface
+interface MollieGatewayConfigFactoryInterface extends FactoryInterface
 {
     public function create(
         MethodInterface $method,

--- a/src/Resources/config/services/resolver.xml
+++ b/src/Resources/config/services/resolver.xml
@@ -95,7 +95,6 @@
             <argument type="service" id="sylius.repository.gateway_config"/>
             <argument type="service" id="bit_bag.sylius_mollie_plugin.creator.mollie_methods_creator"/>
         </service>
-        <service id="sylius_mollie_plugin.resolver.mollie_amount_restriction_resolver" class="SyliusMolliePlugin\Resolver\MollieAmountRestrictionResolver"/>
         <service id="sylius_mollie_plugin.resolver.mollie_allowed_methods_resolver" class="SyliusMolliePlugin\Resolver\MollieAllowedMethodsResolver">
             <argument type="service" id="sylius_mollie_plugin.resolver.mollie_api_client_key_resolver"/>
             <argument type="service" id="sylius_mollie_plugin.resolver.payment_locale_resolver"/>


### PR DESCRIPTION
After running the Symfony `php bin/console lint:container` command to check the service container, it flagged a couple of issues

1. The service definition `sylius_mollie_plugin.resolver.mollie_amount_restriction_resolver` references a class that doesn't exist, and I can't see anything that requires that service so I've removed it.
2. `MollieGatewayConfigFactoryInterface` doesn't extend `Sylius\Component\Resource\Factory\FactoryInterface` which was causing this error:
```
[ERROR] Invalid definition for service "sylius_mollie_plugin.controller.mollie_gateway_config": argument 5 of          
         "Sylius\Bundle\ResourceBundle\Controller\ResourceController::__construct()" accepts                            
         "Sylius\Component\Resource\Factory\FactoryInterface", "SyliusMolliePlugin\Factory\MollieGatewayConfigFactory"  
         passed.
```
So changed it to extend the FactoryInterface and implemented the createNew() method by calling the inner factory class.