### PR TITLE
Fix some cases where `$order->getPayments()->last()` can return false

### DIFF
--- a/src/EmailSender/PaymentLinkEmailSender.php
+++ b/src/EmailSender/PaymentLinkEmailSender.php
@@ -32,10 +32,10 @@ final class PaymentLinkEmailSender implements PaymentLinkEmailSenderInterface
 
     public function sendConfirmationEmail(OrderInterface $order, TemplateMollieEmailTranslationInterface $template): void
     {
-        /** @var PaymentInterface $payment */
+        /** @var PaymentInterface|null $payment */
         $payment = $order->getPayments()->last();
 
-        if (0 === count($payment->getDetails())) {
+        if (false === $payment || 0 === count($payment->getDetails())) {
             return;
         }
 

--- a/src/Menu/AdminOrderShowMenuListener.php
+++ b/src/Menu/AdminOrderShowMenuListener.php
@@ -28,7 +28,7 @@ final class AdminOrderShowMenuListener
         /** @var ?PaymentInterface $payment */
         $payment = $order->getPayments()->last();
 
-        if (null === $payment) {
+        if (null === $payment || $payment === false) {
             return;
         }
 

--- a/src/Order/OrderPaymentRefund.php
+++ b/src/Order/OrderPaymentRefund.php
@@ -50,7 +50,7 @@ final class OrderPaymentRefund implements OrderPaymentRefundInterface
 
         /** @var PaymentInterface|null $payment */
         $payment = $order->getPayments()->last();
-        if (null === $payment) {
+        if (null === $payment || false === $payment) {
             $this->loggerAction->addNegativeLog(sprintf('Not fount payment in refund'));
 
             throw new NotFoundHttpException();

--- a/src/Validator/Constraints/PaymentMethodCheckoutValidator.php
+++ b/src/Validator/Constraints/PaymentMethodCheckoutValidator.php
@@ -39,8 +39,13 @@ final class PaymentMethodCheckoutValidator extends ConstraintValidator
     {
         $order = $this->paymentCheckoutOrderResolver->resolve();
 
-        /** @var PaymentInterface $payment */
+        /** @var PaymentInterface|null $payment */
         $payment = $order->getPayments()->last();
+
+        if(null === $payment || false === $payment)
+        {
+            return;
+        }
 
         /** @var ?PaymentMethodInterface $paymentMethod */
         $paymentMethod = $payment->getMethod();


### PR DESCRIPTION
There are some cases where `$order->getPayments()->last()` can return false, and there are checks for if the returned value is null, but in some instances (notably `src/Menu/AdminOrderShowMenuListener.php`) where its possible for an order to have no payments (for example use of a gift voucher or 100% off discount code) and this would lead to 500 server errors.