### PR TITLE
Fix parseTotalToString

### DIFF
--- a/src/Resolver/MollieAllowedMethodsResolver.php
+++ b/src/Resolver/MollieAllowedMethodsResolver.php
@@ -65,6 +65,6 @@ final class MollieAllowedMethodsResolver implements MollieAllowedMethodsResolver
 
     private function parseTotalToString(int $total): string
     {
-        return substr_replace((string) $total, '.', -2, 0);
+        return sprintf('%.2F', $total / 100);
     }
 }


### PR DESCRIPTION
If the order total is less than 1, the total is formatted wrongly.

Eg.

The total is €0,35.
The value stored is "35".

The plugin formats this value to a string, for the mollie API.
The formatted value is ".35" instead of "0.35".

This causes the mollie api to return an exception, which is caught in the MolliePaymentsMethodResolver, and we get no available mollie methods.

The problem is in the parseTotalToString of the MollieAllowedMethodsResolver, as you can see here:
You can see a version with the new and the old function here: ttps://onlinephp.io/c/13c92

API error:

```
field: "amount.value"
message: "(400: Bad Request): The amount contains an invalid value.
```


This is a PR that i made on the old Mollie repo, and that was apparently not ported to this one, but is still an issue. Thanks!