### PR TITLE
Add Klarna one support.

### DIFF
--- a/src/Payments/Methods/KlarnaOne.php
+++ b/src/Payments/Methods/KlarnaOne.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SyliusMolliePlugin\Payments\Methods;
+
+use Mollie\Api\Types\PaymentMethod;
+
+final class KlarnaOne extends AbstractMethod
+{
+    public function getMethodId(): string
+    {
+        return PaymentMethod::KLARNA_ONE;
+    }
+
+    public function getPaymentType(): string
+    {
+        return self::ORDER_API;
+    }
+}

--- a/src/Payments/MethodsInterface.php
+++ b/src/Payments/MethodsInterface.php
@@ -18,6 +18,7 @@ use SyliusMolliePlugin\Payments\Methods\Giropay;
 use SyliusMolliePlugin\Payments\Methods\Ideal;
 use SyliusMolliePlugin\Payments\Methods\In3;
 use SyliusMolliePlugin\Payments\Methods\Kbc;
+use SyliusMolliePlugin\Payments\Methods\KlarnaOne;
 use SyliusMolliePlugin\Payments\Methods\Klarnapaylater;
 use SyliusMolliePlugin\Payments\Methods\KlarnaPayNow;
 use SyliusMolliePlugin\Payments\Methods\Klarnasliceit;
@@ -41,6 +42,7 @@ interface MethodsInterface
         Giropay::class,
         Ideal::class,
         Kbc::class,
+        KlarnaOne::class,
         Klarnapaylater::class,
         Klarnasliceit::class,
         KlarnaPayNow::class,

--- a/src/Payments/PaymentTerms/Options.php
+++ b/src/Payments/PaymentTerms/Options.php
@@ -72,6 +72,7 @@ final class Options
     public static function getOnlyOrderAPIMethods(): array
     {
         return [
+            PaymentMethod::KLARNA_ONE,
             PaymentMethod::KLARNA_PAY_NOW,
             PaymentMethod::KLARNA_PAY_LATER,
             PaymentMethod::KLARNA_SLICE_IT,

--- a/tests/Application/templates/bundles/SyliusAdminBundle/PaymentMethod/_mollieMethodsForm.html.twig
+++ b/tests/Application/templates/bundles/SyliusAdminBundle/PaymentMethod/_mollieMethodsForm.html.twig
@@ -1,5 +1,6 @@
 {% set mealvouchersId = constant('SyliusMolliePlugin\\Payments\\Methods\\MealVoucher::MEAL_VOUCHERS') %}
 {% set applePay = constant('Mollie\\Api\\Types\\PaymentMethod::APPLEPAY') %}
+{% set klarnaOne = constant('Mollie\\Api\\Types\\PaymentMethod::KLARNA_ONE') %}
 {% set klarnaPayLater = constant('Mollie\\Api\\Types\\PaymentMethod::KLARNA_PAY_LATER') %}
 {% set klarnaSliceIt = constant('Mollie\\Api\\Types\\PaymentMethod::KLARNA_SLICE_IT') %}
 {% set billie = constant('Mollie\\Api\\Types\\PaymentMethod::BILLIE') %}
@@ -133,6 +134,7 @@
                             <div class="twelve wide field">
                                 {% if
                                     methodForm.vars.value.methodId == mealvouchersId or
+                                    methodForm.vars.value.methodId == klarnaOne or
                                     methodForm.vars.value.methodId == klarnaPayLater or
                                     methodForm.vars.value.methodId == klarnaSliceIt or
                                     methodForm.vars.value.methodId == billie or


### PR DESCRIPTION
This adds suport for the Klarna One payment flow, used for Klarna in the UK which as I understand it is still in the beta period. 

This requires at least version 2.62.0 of mollie/mollie-api-php to use the `PaymentMethod::KLARNA_ONE` const, might be worth adding a not about this in the release notes or start an UPGRADING.md file mentioning this fact.