### PR TITLE
Fix for no selection payment method

### DIFF
--- a/src/Action/ConvertMolliePaymentAction.php
+++ b/src/Action/ConvertMolliePaymentAction.php
@@ -108,7 +108,10 @@ final class ConvertMolliePaymentAction extends BaseApiAwareAction implements Act
         } else {
             $paymentMethod = $paymentOptions['molliePaymentMethods'] ?? null;
             $cartToken = $paymentOptions['cartToken'];
-            $selectedIssuer = PaymentMethod::IDEAL === $paymentMethod ? $paymentOptions['issuers']['id'] : null;
+            $selectedIssuer = null;
+            if (PaymentMethod::IDEAL === $paymentMethod && null !== $paymentOptions['issuers']) {
+                $selectedIssuer = $paymentOptions['issuers']['id'];
+            }
         }
 
         /** @var MollieGatewayConfigInterface $method */


### PR DESCRIPTION
If no Ideal issuer is selected in the checkout, the `$paymentOptions['issuers']` returns null and triggers a Symfony exception with the message `Warning: Trying to access array offset on value of type null` in development.
Added a simple null check for `$paymentOptions['issuers']`.