### PR TITLE
Don't put the migrations path on the top of the config

### DIFF
--- a/src/DependencyInjection/SyliusMollieExtension.php
+++ b/src/DependencyInjection/SyliusMollieExtension.php
@@ -29,10 +29,11 @@ final class SyliusMollieExtension extends Extension implements PrependExtensionI
             return;
         }
 
+        $doctrineConfig = $container->getExtensionConfig('doctrine_migrations');
         $container->prependExtensionConfig('doctrine_migrations', [
-            'migrations_paths' => [
+            'migrations_paths' => \array_merge(\array_pop($doctrineConfig)['migrations_paths'] ?? [], [
                 'SyliusMolliePlugin\Migrations' => __DIR__ . '/../Migrations',
-            ],
+            ]),
         ]);
 
         $container->prependExtensionConfig('sylius_labs_doctrine_migrations_extra', [


### PR DESCRIPTION
Make sure the applications default migrations path stay on the top of the list. Otherwise we overwrite the default migrations path for the entire application. 
This is the way that adding migrations paths is also done in the Sylius Core bundle (see https://github.com/Sylius/Sylius/blob/1.13/src/Sylius/Bundle/CoreBundle/DependencyInjection/PrependDoctrineMigrationsTrait.php)