### PR TITLE
Remove stale service definition from validators.xml

### DIFF
--- a/src/Resources/config/services/validators.xml
+++ b/src/Resources/config/services/validators.xml
@@ -36,11 +36,5 @@
         <service id="Sylius\RefundPlugin\Validator\RefundUnitsCommandValidatorInterface"
                  alias="sylius_mollie_plugin.validator.refund.refund_units_command_validator"
         />
-
-        <service id="sylius_mollie_plugin.validator.constraints.mollie_min_max_validator"
-                 class="SyliusMolliePlugin\Validator\Constraints\MollieMinMaxValidator">
-            <tag name="validator.constraint_validator"/>
-            <argument type="service" id="sylius_mollie_plugin.repository.mollie_gateway_config"/>
-        </service>
     </services>
 </container>


### PR DESCRIPTION
The associated class (`SyliusMolliePlugin\Validator\Constraints\MollieMinMaxValidator`) was removed in https://github.com/mollie/Sylius/commit/2e68edcfed5b30b5c746ad32b5ccadb40121fb5b#diff-97d540c2962c566d6e483de01bb1daaa31d89419062ac2dac7068f60571f784c.