### PR TITLE
Fix routing of mollie_admin_methods

### DIFF
--- a/tests/Application/templates/bundles/SyliusAdminBundle/PaymentMethod/_mollieMethodsForm.html.twig
+++ b/tests/Application/templates/bundles/SyliusAdminBundle/PaymentMethod/_mollieMethodsForm.html.twig
@@ -27,7 +27,7 @@
             </div>
             <div class="right aligned column">
                 <div class="ui buttons js-header-btn">
-                    <a href="#" id="get_methods" data-url="{{ path('mollie_admin_methods', {id: resource.id}) }}"
+                    <a href="#" id="get_methods" data-url="{{ path('mollie_admin_methods', {id: resource.gatewayConfig.id}) }}"
                        class="ui button primary">{{ 'sylius_mollie_plugin.ui.load_methods_button'|trans }}</a>
                 </div>
             </div>


### PR DESCRIPTION
MethodsAction controller expects provided ID to be that of a GatewayConfig, but the template used that of the active resource (PaymentMethod ID)

There's no guarantee that PaymentMethod will always have the same ID as it's GatewayConfig