### PR TITLE
Remove hard coded divisors

### DIFF
--- a/src/Controller/Action/Shop/QrCodeAction.php
+++ b/src/Controller/Action/Shop/QrCodeAction.php
@@ -10,6 +10,7 @@ use SyliusMolliePlugin\DTO\MolliePayment\Amount;
 use SyliusMolliePlugin\DTO\MolliePayment\Metadata;
 use SyliusMolliePlugin\DTO\MolliePayment\MolliePayment;
 use SyliusMolliePlugin\Entity\OrderInterface;
+use SyliusMolliePlugin\Helper\IntToStringConverterInterface;
 use SyliusMolliePlugin\Logger\MollieLoggerActionInterface;
 use SyliusMolliePlugin\Resolver\MollieApiClientKeyResolverInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -43,6 +44,9 @@ final class QrCodeAction
     /** @var RepositoryInterface */
     private $methodRepository;
 
+    /** @var IntToStringConverterInterface */
+    private $intToStringConverter;
+
     /**
      * QrCodeAction constructor
      */
@@ -53,7 +57,8 @@ final class QrCodeAction
         MollieApiClientKeyResolverInterface $apiClientKeyResolver,
         OrderRepositoryInterface $orderRepository,
         UrlGeneratorInterface $urlGenerator,
-        RepositoryInterface $methodRepository
+        RepositoryInterface $methodRepository,
+        IntToStringConverterInterface $intToStringConverter
     )
     {
         $this->loggerAction = $loggerAction;
@@ -63,6 +68,7 @@ final class QrCodeAction
         $this->orderRepository = $orderRepository;
         $this->urlGenerator = $urlGenerator;
         $this->methodRepository = $methodRepository;
+        $this->intToStringConverter = $intToStringConverter;
     }
 
     /**
@@ -189,7 +195,7 @@ final class QrCodeAction
     private function buildPaymentObject(Request $request, OrderInterface $order): MolliePayment
     {
         $molliePayment = new MolliePayment();
-        $molliePayment->setAmount(new Amount((string)($order->getTotal() / 100), $order->getCurrencyCode()));
+        $molliePayment->setAmount(new Amount($this->intToStringConverter->convertIntToString($order->getTotal()), $order->getCurrencyCode()));
         $molliePayment->setMethod($request->get('paymentMethod'));
         $molliePayment->setDescription((string)$order->getId());
         $molliePayment->setIssuer($request->get('issuer') ?? '');

--- a/src/Resolver/MolliePaymentsMethodResolver.php
+++ b/src/Resolver/MolliePaymentsMethodResolver.php
@@ -11,6 +11,7 @@ use SyliusMolliePlugin\Entity\MollieGatewayConfig;
 use SyliusMolliePlugin\Entity\MollieGatewayConfigInterface;
 use SyliusMolliePlugin\Entity\OrderInterface as MollieOrderInterface;
 use SyliusMolliePlugin\Logger\MollieLoggerActionInterface;
+use SyliusMolliePlugin\Provider\Divisor\DivisorProviderInterface;
 use SyliusMolliePlugin\Repository\MollieGatewayConfigRepository;
 use SyliusMolliePlugin\Repository\MollieGatewayConfigRepositoryInterface;
 use SyliusMolliePlugin\Repository\PaymentMethodRepositoryInterface;
@@ -49,6 +50,9 @@ final class MolliePaymentsMethodResolver implements MolliePaymentsMethodResolver
     /** @var MollieFactoryNameResolverInterface */
     private $mollieFactoryNameResolver;
 
+    /** @var DivisorProviderInterface */
+    private $divisorProvider;
+
     public function __construct(
         MollieGatewayConfigRepository $mollieGatewayRepository,
         MollieCountriesRestrictionResolverInterface $countriesRestrictionResolver,
@@ -57,7 +61,8 @@ final class MolliePaymentsMethodResolver implements MolliePaymentsMethodResolver
         PaymentMethodRepositoryInterface $paymentMethodRepository,
         MollieAllowedMethodsResolverInterface $allowedMethodsResolver,
         MollieLoggerActionInterface $loggerAction,
-        MollieFactoryNameResolverInterface $mollieFactoryNameResolver
+        MollieFactoryNameResolverInterface $mollieFactoryNameResolver,
+        DivisorProviderInterface $divisorProvider
     ) {
         $this->mollieGatewayRepository = $mollieGatewayRepository;
         $this->countriesRestrictionResolver = $countriesRestrictionResolver;
@@ -67,6 +72,7 @@ final class MolliePaymentsMethodResolver implements MolliePaymentsMethodResolver
         $this->allowedMethodsResolver = $allowedMethodsResolver;
         $this->loggerAction = $loggerAction;
         $this->mollieFactoryNameResolver = $mollieFactoryNameResolver;
+        $this->divisorProvider = $divisorProvider;
     }
 
     public function resolve(): array
@@ -128,7 +134,7 @@ final class MolliePaymentsMethodResolver implements MolliePaymentsMethodResolver
             return $this->getDefaultOptions();
         }
 
-        $allowedMethods = $this->filterPaymentMethods($paymentConfigs, $allowedMethodsIds, (float)$order->getTotal()/100);
+        $allowedMethods = $this->filterPaymentMethods($paymentConfigs, $allowedMethodsIds, (float)$order->getTotal()/$this->divisorProvider->getDivisor());
 
         if (0 === count($allowedMethods)) {
             return $this->getDefaultOptions();

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -49,6 +49,7 @@
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="router" />
             <argument type="service" id="sylius_mollie_plugin.repository.mollie_gateway_config"/>
+            <argument type="service" id="sylius_mollie_plugin.helper.int_to_string"/>
         </service>
         <service id="sylius_mollie_plugin.controller.action.shop.payum_controller" class="SyliusMolliePlugin\Controller\Action\Shop\PayumController">
             <argument type="service" id="payum" />

--- a/src/Resources/config/services/resolver.xml
+++ b/src/Resources/config/services/resolver.xml
@@ -13,6 +13,7 @@
             <argument type="service" id="sylius_mollie_plugin.resolver.mollie_allowed_methods_resolver"/>
             <argument type="service" id="sylius_mollie_plugin.logger.mollie_logger_action"/>
             <argument type="service" id="sylius_mollie_plugin.resolver.mollie_factory_name"/>
+            <argument type="service" id="sylius_mollie_plugin.provider.divisor.divisor_provider"/>
         </service>
         <service id="sylius_mollie_plugin.resolver.payment_methods_image" class="SyliusMolliePlugin\Resolver\MolliePaymentMethodImageResolver">
             <argument>%images_dir%</argument>


### PR DESCRIPTION
There are a few Sylius users who store their prices at a different prescicion to the Sylius default, and need to use a different divisor when converting to and from the int price value, to allow for easier overiding of this divisor the `IntToStringConverter` and `DivisorProvider` services should be used instead of hardcoding the value of 100, allowing stores that use a different divisor to only override 1 small class instead of quite a few different classes across the plugin.